### PR TITLE
kill rubyforge field

### DIFF
--- a/resque-status.gemspec
+++ b/resque-status.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
     "test/test_resque_plugins_status_hash.rb"
   ]
   s.homepage = "http://github.com/quirkey/resque-status".freeze
-  s.rubyforge_project = "quirkey".freeze
   s.rubygems_version = "2.7.6".freeze
   s.summary = "resque-status is an extension to the resque queue system that provides simple trackable jobs.".freeze
 


### PR DESCRIPTION
Fetching https://github.com/simplifi/resque-status.git
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/patrick/.gem/ruby/2.7.1/bundler/gems/resque-status-bb9a46e3d3f5/resque-status.gemspec:46.